### PR TITLE
Join threads when main thread exit

### DIFF
--- a/watchl.py
+++ b/watchl.py
@@ -5,7 +5,7 @@ import os
 from argparse import ArgumentParser
 from subprocess import Popen, PIPE, STDOUT
 import time
-from threading import Thread, Lock
+from threading import Thread
 from locked import Locked
 
 # TODO : establish consistent capitalization/underscoring naming pattern
@@ -205,6 +205,7 @@ def main():
 	cmd = " ".join(parsed.evaluate)
 
 	# Threads
+	threads = []
 	viewer = Viewer()
 	buffer, bufferUpdated = viewer.getBuffer()
 
@@ -212,6 +213,12 @@ def main():
 
 	viewer.start()
 	refresh.start()
+
+	threads.append(viewer)
+	threads.append(refresh)
+
+	for t in threads:
+		t.join(timeout=1)
 
 if __name__=="__main__":
 	main()


### PR DESCRIPTION
**The issue**: when we want to kill the program with keyboard interrupt (ctrl + c), the program will freeze the terminal
**How to reproduce:** 
```
python watchl.py ./pyview.sh watchl.py
ctrl + c
```


**Fix**: non-daemonic threads will roaming around 
So we provide the solution by joining the threads